### PR TITLE
[NET-176] Convergence Map Fix

### DIFF
--- a/+nla/+net/+result/NetworkTestResult.m
+++ b/+nla/+net/+result/NetworkTestResult.m
@@ -142,9 +142,10 @@ classdef NetworkTestResult < matlab.mixin.Copyable
             obj.last_index = obj.last_index + 1;
         end
 
+        % I'm assuming this is Get Significance Matrix. It's used for the convergence plots button, but the naming makes zero sense
+        % Any help on renaming would be great.
         function [test_number, significance_count_matrix, names] = getSigMat(obj, network_test_options, network_atlas, flags)
-            % I'm assuming this is Get Significance Matrix. It's used for the convergence plots button, but the naming makes zero sense
-            % Any help on renaming would be great.
+            
             import nla.TriMatrix nla.TriMatrixDiag
 
             test_number = 0;
@@ -447,6 +448,22 @@ classdef NetworkTestResult < matlab.mixin.Copyable
             if ~obj.is_noncorrelation_input && plot_test_type == "within_network_pair"
                 p_value = strcat("single_sample_", p_value);
             end
+        end
+        
+        % I don't really know what these do and haven't really thought about it. Hence the bad naming.
+        function [sig, name] = singleSigMat(obj, network_atlas, edge_test_options, p_value, mcc_method, title_prefix)
+            p_value_max = mcc_method.correct(network_atlas, edge_test_options, p_value);
+            p_breakdown_labels = mcc_method.createLabel(network_atlas, edge_test_options, p_value);
+
+            sig = nla.TriMatrix(network_atlas.numNets(), 'double', nla.TriMatrixDiag.KEEP_DIAGONAL);
+            sig.v = (p_value.v < p_value_max);
+            name = sprintf("%s %s P < %.2g (%s)", title_prefix, obj.test_display_name, p_value_max, p_breakdown_labels);
+        end
+
+        function [number_of_tests, sig_count_mat, names] = appendSignificanceMatrix(obj, number_of_tests, sig_count_mat, names, sig, name)
+            number_of_tests = number_of_tests + 1;
+            sig_count_mat.v = sig_count_mat.v + sig.v;
+            names = [names name];
         end
     end
 


### PR DESCRIPTION
There were two functions missing in the NetworkTestResult to make the convergence map plots work.

Why the functions are sigmat (significance matrix?) and not convergence matrix is beyond me. Please rename them if you work on them