### PR TITLE
NET-181 Fix permutation results in ResultPool

### DIFF
--- a/+nla/TestPool.m
+++ b/+nla/TestPool.m
@@ -276,6 +276,7 @@ classdef TestPool < nla.DeepCopyable
                 ranker = ResultRank(nonpermuted_network_test_results{test}, permuted_network_results{test}, number_of_network_pairs);
                 ranked_results_object = ranker.rank();
                 ranked_results{test} = ranked_results_object;
+                ranked_results{test}.permutation_results = permuted_network_results{test}.permutation_results;
             end
         end
     end


### PR DESCRIPTION
The actual permutations themselves were not copying over. Fixed that.