### PR TITLE
NET182 - Fix matrixplot scaling

### DIFF
--- a/+nla/+gfx/+plots/MatrixPlot.m
+++ b/+nla/+gfx/+plots/MatrixPlot.m
@@ -53,6 +53,10 @@ classdef MatrixPlot < handle
             "Bone", "Copper", "Pink"}; % Colorbar choices
     end
 
+    properties (SetAccess = immutable)
+        original_matrix % The original matrix for scaling purposes
+    end
+
     methods
         function obj = MatrixPlot(figure, name, matrix, networks, figure_size, varargin)
             % MatrixPlot constructor
@@ -112,7 +116,7 @@ classdef MatrixPlot < handle
                     end
                 end
             end
-
+            obj.original_matrix = matrix;
         end
 
         function displayImage(obj)
@@ -630,6 +634,8 @@ classdef MatrixPlot < handle
             % Only works with APPLY button, will not work with only CLOSE
         
             import nla.net.result.NetworkResultPlotParameter nla.gfx.ProbPlotMethod
+
+            obj.matrix = obj.original_matrix;
 
             button_group_value = get(get(button_group, "SelectedObject"), "String");
 


### PR DESCRIPTION
Before Matrixplot was directly scaling the data. This led to an issue where if you scaled from 0.5 -> 0.3 there was no way to go up from 0.3 again. Fixes that.