### PR TITLE
[NET-216] Make `commitString.m` shell agnostic

### DIFF
--- a/+nla/+helpers/+git/commitString.m
+++ b/+nla/+helpers/+git/commitString.m
@@ -3,8 +3,8 @@ function str = commitString(full)
     
     if ~exist('full', 'var'), full = false; end
     
-    cmd_str = sprintf('cd %s\ngit rev-parse %%s HEAD', nla.findRootPath());
-    [cmd_status, branch_name] = system(sprintf(cmd_str, '--abbrev-ref'));
+    cmd_str = sprintf('cd %s\ngit rev-parse --abbrev-ref HEAD', nla.findRootPath());
+    [cmd_status, branch_name] = system(sprintf(cmd_str));
     if cmd_status ~= 0
         str = 'Failed to locate git repository';
         return


### PR DESCRIPTION
For some reason, the `sprintf` is split into two lines. It's always going to be `git rev-parse --abbrev-ref HEAD`; just do it in one line.