### PR TITLE
[NET-233] Full Connectome Changes

### DIFF
--- a/+nla/+net/+result/NetworkTestResult.m
+++ b/+nla/+net/+result/NetworkTestResult.m
@@ -169,7 +169,7 @@ classdef NetworkTestResult < matlab.mixin.Copyable
             if isfield(flags, "show_full_conn") && flags.show_full_conn
                 title = "Full Connectome";
                 p_values = obj.full_connectome.uncorrected_two_sample_p_value;
-                fdr_method = nla.net.mcc.None;
+                fdr_method = network_test_options.fdr_correction;
             end
             if isfield(flags, "show_within_net_pair") && flags.show_within_net_pair
                 title = "Within Network Pair";


### PR DESCRIPTION
Changes for full connectome
1. Change calculation from whole connectome vs single network to network against itself
2. Change to allow corrections for full connectome plotting

Changes:
- All denominators in ranking are 1 + permutations (this made things much easier)
- Combined statistics is now done the same way for within network pair and full connectome (again, things easier)
- Code tidying
- Net decrease in lines! (would've been more had I not limited lines to 120)