### PR TITLE
[NET-229] Both Benjamini corrections causing errors

### DIFF
--- a/+nla/+net/+result/+plot/NetworkTestPlot.m
+++ b/+nla/+net/+result/+plot/NetworkTestPlot.m
@@ -72,7 +72,8 @@ classdef NetworkTestPlot < handle
 
         function getPlotTitle(obj)
             import nla.NetworkLevelMethod
-
+            
+            obj.title = "";
             % Building the plot title by going through options
             switch obj.test_method
                 case NetworkLevelMethod.NO_PERMUTATIONS
@@ -149,10 +150,17 @@ classdef NetworkTestPlot < handle
             [width, height, obj.matrix_plot] = plotter.plotProbability(obj.plot_figure, probability_parameters,...
                 nla.inputField.LABEL_GAP, obj.y_position + obj.panel_height);
             
-            obj.settings{7}.field.Value = str2double(obj.matrix_plot.color_bar.TickLabels{end});
-            obj.settings{8}.field.Value = str2double(obj.matrix_plot.color_bar.TickLabels{1});
-            obj.current_settings.upper_limit = str2double(obj.matrix_plot.color_bar.TickLabels{end});
-            obj.current_settings.lower_limit = str2double(obj.matrix_plot.color_bar.TickLabels{1});
+            if probability_parameters.p_value_plot_max > 0
+                obj.settings{7}.field.Value = str2double(obj.matrix_plot.color_bar.TickLabels{end});
+                obj.settings{8}.field.Value = str2double(obj.matrix_plot.color_bar.TickLabels{1});
+                obj.current_settings.upper_limit = str2double(obj.matrix_plot.color_bar.TickLabels{end});
+                obj.current_settings.lower_limit = str2double(obj.matrix_plot.color_bar.TickLabels{1});
+            else
+                obj.settings{7}.field.Value = 0;
+                obj.settings{8}.field.Value = 0;
+                obj.current_settings.upper_limit = 0;
+                obj.current_settings.lower_limit = 0;
+            end
         end
 
         function drawChord(obj, ~, ~, plot_type)

--- a/+nla/+net/+result/NetworkResultPlotParameter.m
+++ b/+nla/+net/+result/NetworkResultPlotParameter.m
@@ -59,6 +59,10 @@ classdef NetworkResultPlotParameter < handle
 
             name_label = sprintf("%s %s\nP < %.2g (%s)", obj.network_test_results.test_display_name, plot_title,...
                 p_value_max, p_value_breakdown_label);
+            if p_value_max == 0
+                name_label = sprintf("%s %s\nP = %.2g (%s)", obj.network_test_results.test_display_name, plot_title,...
+                    p_value_max, p_value_breakdown_label);
+            end
 
             % Filtering if there's a filter provided 
             significance_plot = TriMatrix(obj.number_of_networks, "logical", TriMatrixDiag.KEEP_DIAGONAL);

--- a/+nla/+net/+result/NetworkTestResult.m
+++ b/+nla/+net/+result/NetworkTestResult.m
@@ -290,6 +290,9 @@ classdef NetworkTestResult < matlab.mixin.Copyable
             sig = nla.TriMatrix(network_atlas.numNets(), 'double', nla.TriMatrixDiag.KEEP_DIAGONAL);
             sig.v = (p_value.v < p_value_max);
             name = sprintf("%s %s P < %.2g (%s)", title_prefix, obj.test_display_name, p_value_max, p_breakdown_labels);
+            if p_value_max == 0
+                name = sprintf("%s %s P = 0 (%s)", title_prefix, obj.test_display_name, p_breakdown_labels);
+            end
         end
 
         function [number_of_tests, sig_count_mat, names] = appendSignificanceMatrix(...


### PR DESCRIPTION
There were a couple of errors. 

The first is that if p_value_max = 0, the colorbar tries to create a scale from [1 1 1]. This is a colormap consisting of white. Nothing else. This will error when trying to calculate the spread of top to bottom. The scale is easy 1 -> 1. That's a scale of length 0, so we'll get NaN for the min and max. That's the error. Put a conditional in to assign 0 to the max and min scale if this is the situation.

Second error is much the same. Normally we have something like `P < 0.05` in the title. If there's no scale, that means there's no data, so `P = 0`

Finally, in a related issue, NET-234, the title is appending itself instead of re-initializing. Just added a clear before the title is assigned.