### PR TITLE
[NET-289] - Error when calling MCC with Chord plots

### DIFF
--- a/+nla/+net/+result/NetworkResultPlotParameter.m
+++ b/+nla/+net/+result/NetworkResultPlotParameter.m
@@ -51,7 +51,7 @@ classdef NetworkResultPlotParameter < handle
 
             % Get the scale max and the labels
             if isstring(fdr_correction) || ischar(fdr_correction)
-                fdr_correction = nla.net.mcc.(fdr_correction)();
+                fdr_correction = nla.net.mcc.(erase(fdr_correction, "-"))();
             end
             p_value_max = fdr_correction.correct(obj.network_atlas, obj.updated_test_options, statistic_input);
             p_value_breakdown_label = fdr_correction.createLabel(obj.network_atlas, obj.updated_test_options,...


### PR DESCRIPTION
When using either of the Benjamini MCC with the chord plots there's an error. This is caused by the name having a hyphen and the file names not. Just remove the hyphen when calling the correction